### PR TITLE
make the customer border display correctly

### DIFF
--- a/index-src.html
+++ b/index-src.html
@@ -7,8 +7,10 @@
   </head>
   <body>
     <div id="bg"></div>
-    <div id="kiosk-window">
-      <img id="visitor"></div>
+    <div id="kiosk-window-decs">
+      <div id="kiosk-window">
+        <img id="visitor">
+      </div>
     </div>
     <div id="text-box"></div>
     <div id="item-list"></div>

--- a/style.css
+++ b/style.css
@@ -17,6 +17,7 @@
 }
 
 body {
+  text-align: center;
   font-family: sans-serif;
   background-color: #101359;
 }
@@ -32,14 +33,18 @@ body {
   animation: tokimeki-memorial 4s linear infinite;
 }
 
+#kiosk-window-decs {
+  position: relative;
+  display: inline-block;
+  background-image: url("art/customer_window_border.svg");
+}
+
 #kiosk-window {
   width: 700px;
   height: 500px;
-  margin: 1em auto;
+  margin: 25px;
   position: relative;
   overflow: hidden;
-  border: 24px solid;  /* this is dependant on the border svg and the screen's pixel density; i think the svg using px is a problem maybe */
-  border-image: url("art/customer_window_border.svg") 12;
   background-image: url("art/trainstation_background_no_border_4x.png");
   background-size: cover;
   background-clip: padding-box;


### PR DESCRIPTION
The problem wasn't the pixel sizing in the SVG, it was the percentage sizing in the SVG—not really being aware how `border-image` works, I designed an SVG that would responsively size to whatever container it is placed in, with fixed-size corners and a variably-sized content area. This is completely incompatible with the assumptions made by `border-image`, which assumes it's taking a fixed-size non-responsive image and slicing it up. This PR avoids the problem by not using `border-image`; an alternative would be switching the SVG to be fixed size (in pixels or otherwise).

I'm no web developer, so not sure which is the better option. Having one image automatically size feels better to me, since you're not stretching or tiling parts of an SVG, which seems a weird thing to do, and did give us problems with the repeating background at non-default zoom levels.